### PR TITLE
Fix: Prevent recursion error during game reset

### DIFF
--- a/3_BreakoutPlus/js/game.js
+++ b/3_BreakoutPlus/js/game.js
@@ -420,8 +420,10 @@ function _restoreBricks(brickData) {
 
         // If not restoring from savedState, _buildBricks was already called.
         // If restoring, bricks are cleared, and _restoreBricks placeholder is noted.
-        // _resetBall will handle initial ball position.
-        _resetBall();
+        // _resetBall will handle initial ball position, but only if not restoring from a saved state.
+        if (!savedState) {
+            _resetBall();
+        }
         
         _gameLoopId = true;
         _nextLoopIteration();


### PR DESCRIPTION
A 'too much recursion' error occurred when the player lost a life. This was due to an unconditional call to `_resetBall()` within the `_startGame()` function, which itself was called as part of the game reset sequence initiated by `_resetBall()`.

The fix involves adding a condition to the `_resetBall()` call within `_startGame()`. Now, `_resetBall()` is only invoked if `_startGame()` is not being called with a `savedState` argument. This ensures that the function is not called again when the game is restoring its state after a life is lost, thereby breaking the recursive loop.