### PR TITLE
Fix: Correct paddle movement and ball launch issues

### DIFF
--- a/3_BreakoutPlus/js/game.js
+++ b/3_BreakoutPlus/js/game.js
@@ -411,7 +411,7 @@ function _restoreBricks(brickData) {
         }
 
         $(document).off("mousemove.game").on("mousemove.game", function (event) {
-            _mouseX = event.clientX;
+            _mouseX = event.clientX - _gameStagePos.left;
         });
         _$gameStage.off("click.game");
 


### PR DESCRIPTION
The paddle was not reacting to mouse movements correctly because the `_mouseX` variable was being calculated based on `event.clientX`, which is relative to the viewport, not the game stage. This caused incorrect paddle positioning if the game stage was not at the top-left of the viewport.

This commit fixes the issue by calculating `_mouseX` relative to the game stage's left offset: `_mouseX = event.clientX - _gameStagePos.left;`.

This change ensures the paddle follows the mouse accurately within the game boundaries. Consequently, the ball, whose initial position is tied to the paddle, also positions correctly before launch, and the existing ball launch mechanism now functions as expected.